### PR TITLE
allow sentinel list to be passed as a comma-delimited string

### DIFF
--- a/lib/Apache/Session/Browseable/Redis.pm
+++ b/lib/Apache/Session/Browseable/Redis.pm
@@ -29,7 +29,7 @@ sub populate {
 
 sub unserialize {
     my $session = shift;
-    my $tmp = { serialized => $session };
+    my $tmp     = { serialized => $session };
     Apache::Session::Serialize::JSON::unserialize($tmp);
     return $tmp->{data};
 }
@@ -37,19 +37,12 @@ sub unserialize {
 sub searchOn {
     my ( $class, $args, $selectField, $value, @fields ) = @_;
 
-    # Manage undef encoding
-    $args->{encoding} = undef
-      if ( $args->{encoding} and $args->{encoding} eq "undef" );
-
     my %res = ();
     my $index =
       ref( $args->{Index} ) ? $args->{Index} : [ split /\s+/, $args->{Index} ];
     if ( grep { $_ eq $selectField } @$index ) {
-        my $redisObj = $redis->new(%$args);
 
-        # Manage database
-        $redisObj->select( $args->{database} ) if defined $args->{database};
-
+        my $redisObj = $class->_getRedis($args);
         my @keys = $redisObj->smembers("${selectField}_$value");
         foreach my $k (@keys) {
             next unless ($k);
@@ -92,16 +85,7 @@ sub get_key_from_all_sessions {
     my $data  = shift;
     my %res;
 
-    # Manage undef encoding
-    $args->{encoding} = undef
-      if ( $args->{encoding} and $args->{encoding} eq "undef" );
-
-    # TODO new Redis object
-    my $redisObj = $redis->new(%$args);
-
-    # Manage database
-    $redisObj->select( $args->{database} ) if defined $args->{database};
-
+    my $redisObj = $class->_getRedis($args);
     my @keys = $redisObj->keys('*');
     foreach my $k (@keys) {
         next if ( !$k or $k =~ /_/ );
@@ -120,6 +104,32 @@ sub get_key_from_all_sessions {
         }
     }
     return \%res;
+}
+
+sub _getRedis {
+    my $class = shift;
+    my $args  = shift;
+
+    # Manage undef encoding
+    $args->{encoding} = undef
+      if (  $args->{encoding}
+        and $args->{encoding} eq "undef" );
+
+    # If sentinels is not given as an array ref, try to parse
+    # a comma delimited list instead
+    if ( $args->{sentinels}
+        and ref $args->{sentinels} ne 'ARRAY' )
+    {
+        $args->{sentinels} =
+          [ split /[,\s]+/, $args->{sentinels} ];
+    }
+
+    my $redisObj = $redis->new( %{$args} );
+
+    # Manage database
+    $redisObj->select( $args->{database} )
+      if defined $args->{database};
+    return $redisObj;
 }
 
 1;

--- a/lib/Apache/Session/Browseable/Store/Redis.pm
+++ b/lib/Apache/Session/Browseable/Store/Redis.pm
@@ -23,6 +23,15 @@ sub new {
       if (  $session->{args}->{encoding}
         and $session->{args}->{encoding} eq "undef" );
 
+    # If sentinels is not given as an array ref, try to parse
+    # a comma delimited list instead
+    if ( $session->{args}->{sentinels}
+        and ref $session->{args}->{sentinels} ne 'ARRAY' )
+    {
+        $session->{args}->{sentinels} =
+          [ split /[,\s]+/, $session->{args}->{sentinels} ];
+    }
+
     $self->{cache} = $redis->new( %{ $session->{args} } );
 
     # Manage database


### PR DESCRIPTION
LemonLDAP::NG only allows module args to be specified as strings. This commit lets the user specify the sentinels list in the form `127.0.0.1:26379,127.0.0.2:26379,127.0.0.3:26379`