### PR TITLE
Add specific error handling for old versions

### DIFF
--- a/lib/Apache/Session/Browseable/Store/LDAP.pm
+++ b/lib/Apache/Session/Browseable/Store/LDAP.pm
@@ -186,8 +186,7 @@ sub ldap {
         if (    $ldap->socket->isa('IO::Socket::SSL')
             and $ldap->socket->errstr < 0 )
         {
-            $self->logError( "SSL connection error: " . $ldap->socket->errstr );
-            return;
+            die( "SSL connection error: " . $ldap->socket->errstr );
         }
     }
 


### PR DESCRIPTION
Use code from @maxbes to better handle SSL errors for CentOS 7