### PR TITLE
Fix race condition in Redis module

### DIFF
--- a/lib/Apache/Session/Browseable/Redis.pm
+++ b/lib/Apache/Session/Browseable/Redis.pm
@@ -97,6 +97,7 @@ sub get_key_from_all_sessions {
         next if ( !$k or $k =~ /_/ );
         eval {
             my $v   = $redisObj->get($k);
+            next unless $v;
             my $tmp = unserialize($v);
             if ( ref($data) eq 'CODE' ) {
                 $tmp = &$data( $tmp, $k );


### PR DESCRIPTION
In gkfas, we first get the list of keys then iterate on them, but in the meantime, some keys may have been deleted by another process (user logs out, session purge...). We need to skip over keys that no longer have value to avoid a useless error message on those keys