### PR TITLE
Revert 291297615279136d61be293668d96e19b3f79c16

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,7 +8,7 @@ Module::Build->new(
     requires      => { 'Apache::Session' => 0, 'JSON' => 0, },
     recommends    => { 'DBI' => 0, 'Net::LDAP' => 0.38, },
     test_requires => { DBI => 0, 'DBD::SQLite' => 0, },
-    dist_version  => '1.3.11',
+    dist_version  => '1.3.10',
     autosplit     => [qw(lib/Apache/Session/Browseable/_common.pm)],
     configure_requires => { 'Module::Build' => 0, },
     meta_merge => {

--- a/Changes
+++ b/Changes
@@ -1,8 +1,5 @@
 Revision history for Perl extension Apache::Session::Browseable.
 
-1.3.11
-    - Revert 1.3.10 changes
-
 1.3.10
     - Add quote for fields in INSERT query
 

--- a/META.json
+++ b/META.json
@@ -39,7 +39,7 @@
    "provides" : {
       "Apache::Session::Browseable" : {
          "file" : "lib/Apache/Session/Browseable.pm",
-         "version" : "v1.3.11"
+         "version" : "v1.3.10"
       },
       "Apache::Session::Browseable::DBI" : {
          "file" : "lib/Apache/Session/Browseable/DBI.pm",
@@ -91,7 +91,7 @@
       },
       "Apache::Session::Browseable::Store::DBI" : {
          "file" : "lib/Apache/Session/Browseable/Store/DBI.pm",
-         "version" : "v1.3.11"
+         "version" : "v1.3.10"
       },
       "Apache::Session::Browseable::Store::File" : {
          "file" : "lib/Apache/Session/Browseable/Store/File.pm",
@@ -155,6 +155,6 @@
          "url" : "https://github.com/LemonLDAPNG/Apache-Session-Browseable"
       }
    },
-   "version" : "v1.3.11",
+   "version" : "v1.3.10",
    "x_serialization_backend" : "JSON::PP version 4.06"
 }

--- a/META.yml
+++ b/META.yml
@@ -17,7 +17,7 @@ name: Apache-Session-Browseable
 provides:
   Apache::Session::Browseable:
     file: lib/Apache/Session/Browseable.pm
-    version: v1.3.11
+    version: v1.3.10
   Apache::Session::Browseable::DBI:
     file: lib/Apache/Session/Browseable/DBI.pm
     version: v1.3.9
@@ -56,7 +56,7 @@ provides:
     version: v1.2.2
   Apache::Session::Browseable::Store::DBI:
     file: lib/Apache/Session/Browseable/Store/DBI.pm
-    version: v1.3.11
+    version: v1.3.10
   Apache::Session::Browseable::Store::File:
     file: lib/Apache/Session/Browseable/Store/File.pm
     version: v1.2.2
@@ -105,5 +105,5 @@ requires:
 resources:
   license: http://dev.perl.org/licenses/
   repository: https://github.com/LemonLDAPNG/Apache-Session-Browseable
-version: v1.3.11
+version: v1.3.10
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/lib/Apache/Session/Browseable.pm
+++ b/lib/Apache/Session/Browseable.pm
@@ -1,6 +1,6 @@
 package Apache::Session::Browseable;
 
-our $VERSION = '1.3.11';
+our $VERSION = '1.3.10';
 
 print STDERR "Use a sub module of Apache::Session::Browseable such as Apache::Session::Browseable::File";
 

--- a/lib/Apache/Session/Browseable/Store/DBI.pm
+++ b/lib/Apache/Session/Browseable/Store/DBI.pm
@@ -3,7 +3,7 @@ package Apache::Session::Browseable::Store::DBI;
 use strict;
 use Apache::Session::Store::DBI;
 our @ISA     = qw(Apache::Session::Store::DBI);
-our $VERSION = 1.3.11;
+our $VERSION = 1.3.10;
 
 sub insert {
     my ( $self, $session ) = @_;

--- a/lib/Apache/Session/Browseable/Store/DBI.pm
+++ b/lib/Apache/Session/Browseable/Store/DBI.pm
@@ -18,14 +18,12 @@ sub insert {
       : [ split /\s+/, $session->{args}->{Index} ];
 
     if ( !defined $self->{insert_sth} ) {
-        $self->{insert_sth} = $self->{dbh}->prepare_cached(
-            "INSERT INTO $self->{table_name} ("
-              . join( ',',
-                'id', 'a_session',
-                map { s/'/''/g; $self->{dbh}->quote_identifier($_) } @$index )
+        $self->{insert_sth} =
+          $self->{dbh}->prepare_cached( "INSERT INTO $self->{table_name} ("
+              . join( ',', 'id', 'a_session', map { s/'/''/g; $_ } @$index )
               . ') VALUES ('
-              . join( ',', ('?') x ( 2 + @$index ) ) . ')'
-        );
+              . join( ',', ('?') x ( 2 + @$index ) )
+              . ')' );
     }
 
     $self->{insert_sth}->bind_param( 1, $session->{data}->{_session_id} );


### PR DESCRIPTION
291297615279136d61be293668d96e19b3f79c16 breaks existing LemonLDAP::NG installs because LLNG doc creates column name in lowercase and 291297615279136d61be293668d96e19b3f79c16 requests mixed-case table names

Please revert it, there isn't and will probably never be a good solution to handle a column named "user" in Browseable::Postgres, recommendation is to use Browseable::PgJSON