### PR TITLE
Do not die on JSON error in get_key_from_all_sessions

### DIFF
--- a/lib/Apache/Session/Browseable/Redis.pm
+++ b/lib/Apache/Session/Browseable/Redis.pm
@@ -98,7 +98,7 @@ sub get_key_from_all_sessions {
         eval {
             my $v   = $redisObj->get($k);
             next unless $v;
-            my $tmp = unserialize($v);
+            my $tmp = eval { unserialize($v) };
             if ( ref($data) eq 'CODE' ) {
                 $tmp = &$data( $tmp, $k );
                 $res{$k} = $tmp if ( defined($tmp) );


### PR DESCRIPTION
When an error occurs on unserializing a JSON session, the unserialize() sub in lib/Apache/Session/Serialize/JSON.pm calls die().

In other session stores (for example LDAP), when unserialize() is called in the context of get_key_from_all_sessions(), it uses eval{} to catch the error. But here in the Redis store, it does not and get_key_from_all_sessions() is interrupted.

It causes the purgeCentralCache script in lemonldap-ng to exit early and not purge any sessions, when it encounters an invalid/corrupted session.

Please keep in mind that, although this fix is very short, my knowledge of Perl is extremely thin :-)