### PR TITLE
restrict mysql_enable_utf8 to DBD::mysql

### DIFF
--- a/lib/Apache/Session/Browseable/Store/MySQL.pm
+++ b/lib/Apache/Session/Browseable/Store/MySQL.pm
@@ -12,7 +12,9 @@ our $VERSION = '1.2.2';
 sub connection {
     my($self,$session)=@_;
     $self->SUPER::connection($session);
-    $self->{dbh}->{mysql_enable_utf8} = 1;
+    if ( $self->{dbh}->{Driver}->{Name} eq "mysql" ) {
+        $self->{dbh}->{mysql_enable_utf8} = 1;
+    }
 }
 
 1;


### PR DESCRIPTION
Test script:

```
use Apache::Session::Browseable::MySQL;
  
my $args = {
        'DataSource' => 'DBI:MariaDB:database=test;host=localhost',
        'Password' => 'test',
        'TableName' => 'sessions',
        'UserName' => 'test',
};

tie %session, 'Apache::Session::Browseable::MySQL', undef, $args;
```
Version: 10.11.4-MariaDB

result:

```
DBD::MariaDB::db STORE failed: Unknown attribute mysql_enable_utf8
```

This PR only sets mysql_enable_utf8 on DBD::mysql. DBD::MariaDB already does it by default